### PR TITLE
Fix adb install flags

### DIFF
--- a/audiosource
+++ b/audiosource
@@ -87,9 +87,9 @@ install() {
 
 	echo '[+] Installing Audio Source'
 
-	adb $opts install -t -r -g "$AUDIOSOURCE_APK" || {
+	adb $opts install -trg "$AUDIOSOURCE_APK" || {
 		adb $opts uninstall fr.dzx.audiosource
-		adb $opts install -t -g "$AUDIOSOURCE_APK"
+		adb $opts install -tg "$AUDIOSOURCE_APK"
 	}
 }
 

--- a/audiosource
+++ b/audiosource
@@ -87,7 +87,7 @@ install() {
 
 	echo '[+] Installing Audio Source'
 
-	adb $opts install -trg "$AUDIOSOURCE_APK" || {
+	adb $opts install -rtg "$AUDIOSOURCE_APK" || {
 		adb $opts uninstall fr.dzx.audiosource
 		adb $opts install -tg "$AUDIOSOURCE_APK"
 	}


### PR DESCRIPTION
Fix the `Error: Unknown option: -g` and `Failure [INSTALL_FAILED_ALREADY_EXISTS]` errors that can happen during installation