### PR TITLE
Fix adb args error on newer versions of Android

### DIFF
--- a/audiosource
+++ b/audiosource
@@ -82,9 +82,9 @@ install() {
 
 	echo '[+] Installing Audio Source'
 
-	adb install -rtg "$AUDIOSOURCE_APK" || {
+	adb install -r -t -g "$AUDIOSOURCE_APK" || {
 		adb uninstall "$AUDIOSOURCE_PKG"
-		adb install -tg "$AUDIOSOURCE_APK"
+		adb install -t -g "$AUDIOSOURCE_APK"
 	}
 }
 


### PR DESCRIPTION
Modern versions of Android changed how adb command arguments are interpreted. Putting multiple single letter args together, like `-tg` instead of `-t -g` results in an error on recent devices with new software version.

I haven't found official docs mentioning this specificially, but all examples use only a single letter per dash with spacebars in between, and mention that arg parsing now works the same way as the ssh command, talking about how `"strings like these" are now interpreted as a single arg per word instead of one arg that's the entire string of text or whatever, though I guess I'm not sure if it's entirely related.

In any case, the solution is extremely simple, as can be seen in the diff of this PR.

Also to add further proof, here is an issue from another piece of software that I've found which discusses the same problem: https://github.com/novoda/gradle-android-command-plugin/issues/108

The error there is the same one I was having with the current version of the audiosource script.

I already implemented this fix by patching the script [when packaging this software for NixOS](https://github.com/NixOS/nixpkgs/pull/473776), and it's been working perfectly so far, so with the recent 1.5 update I thought it's about time I submit this fix upstream.